### PR TITLE
fix: duplicate resource declarations

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -1,7 +1,4 @@
 # @!visibility private
 class sasl::install {
-
-  package { $::sasl::package_name:
-    ensure => present,
-  }
+  ensure_packages($sasl::package_name, {'ensure' =>  'present'})
 }


### PR DESCRIPTION
Verhindert es aktuell, dass wir auf stdlib v8 wechseln können.